### PR TITLE
Fixing TWINT requires Python version 3.6+

### DIFF
--- a/twint/cli.py
+++ b/twint/cli.py
@@ -331,8 +331,7 @@ def main():
 
 
 def run_as_command():
-    version = ".".join(str(v) for v in sys.version_info[:2])
-    if float(version) < 3.6:
+    if(sys.version_info.major < 3 or (sys.version_info.major == 3 and sys.version_info.minor < 6)):
         print("[-] TWINT requires Python version 3.6+.")
         sys.exit(0)
 


### PR DESCRIPTION
commit to fix issues with python versions following since 3.10