### PR TITLE
Enforce limiter from config

### DIFF
--- a/twint/url.py
+++ b/twint/url.py
@@ -67,7 +67,7 @@ async def MobileProfile(username, init):
 async def Search(config, init):
     logme.debug(__name__ + ':Search')
     url = base
-    tweet_count = 100
+    tweet_count = 100 if not config.Limit else config.Limit
     q = ""
     params = [
         # ('include_blocking', '1'),


### PR DESCRIPTION
Previously the tweet_count was always being set to 100, ignoring the limit config set by the user. This change changes the tweet count limit based on the config.